### PR TITLE
Save \chapter outside of appendix

### DIFF
--- a/faupress.cls
+++ b/faupress.cls
@@ -1092,6 +1092,7 @@
     \protect\renewcommand\protect\chaptertocstyle{\normalsize}%
   }%
 }
+\let\rememberchapterdef\chapter % save chapter command
 \g@addto@macro\appendix{%
   \addtocontents{toc}{%
     \vspace*{0.25em}
@@ -1099,7 +1100,6 @@
     \protect\renewcommand\protect\chaptertocstyle{\small}%
   }%
   \addchap{\appendixname}%
-  \let\rememberchapterdef\chapter
   \let\chapter\relax
   \renewcommand*\thesection{\@Alph\c@section}
 }


### PR DESCRIPTION
If a thesis uses a bibliography but not an appendix, the \backmatter
command redefines the \chapter command to the undefined
\rememberchapterdef command, which results in an obscure error. To fix
this, this commit moves the definition of \rememberchapterdef before the
modification of \appendix.